### PR TITLE
added profile controller tests

### DIFF
--- a/backend/nitconf/src/main/java/com/nitconfbackend/nitconf/controllers/ProfileController.java
+++ b/backend/nitconf/src/main/java/com/nitconfbackend/nitconf/controllers/ProfileController.java
@@ -52,18 +52,14 @@ public class ProfileController {
         String email = SecurityContextHolder.getContext().getAuthentication().getName();
         User user = userRepo.findByEmail(email).orElseThrow();
 
-        if (user != null) {
-            // userRepo.delete(user);
-            if (entity.firstName != null)
-                user.setFirstName(entity.firstName);
-            if (entity.lastName != null)
-                user.setLastName(entity.lastName);
-            if (entity.phoneNumber != null)
-                user.setPhoneNumber(entity.phoneNumber);
-            userRepo.save(user);
-            return ResponseEntity.ok("Updated successfully");
-        }
-        return ResponseEntity.badRequest().build();
+        if (entity.firstName != null)
+            user.setFirstName(entity.firstName);
+        if (entity.lastName != null)
+            user.setLastName(entity.lastName);
+        if (entity.phoneNumber != null)
+            user.setPhoneNumber(entity.phoneNumber);
+        userRepo.save(user);
+        return ResponseEntity.ok("Updated successfully");
     }
 
     /**

--- a/backend/nitconf/src/main/java/com/nitconfbackend/nitconf/types/ProfileRequest.java
+++ b/backend/nitconf/src/main/java/com/nitconfbackend/nitconf/types/ProfileRequest.java
@@ -8,6 +8,5 @@ import lombok.NoArgsConstructor;
 public class ProfileRequest {
     public String firstName;
     public String lastName;
-    public String email;
     public String phoneNumber;
 }

--- a/backend/nitconf/src/test/java/com/nitconfbackend/nitconf/controllers/AuthControllerTest.java
+++ b/backend/nitconf/src/test/java/com/nitconfbackend/nitconf/controllers/AuthControllerTest.java
@@ -1,0 +1,15 @@
+package com.nitconfbackend.nitconf.controllers;
+
+import org.junit.jupiter.api.Test;
+
+public class AuthControllerTest {
+    @Test
+    void testLogin() {
+
+    }
+
+    @Test
+    void testRegisterUser() {
+
+    }
+}

--- a/backend/nitconf/src/test/java/com/nitconfbackend/nitconf/controllers/ProfileControllerTest.java
+++ b/backend/nitconf/src/test/java/com/nitconfbackend/nitconf/controllers/ProfileControllerTest.java
@@ -89,6 +89,29 @@ public class ProfileControllerTest {
     }
 
     @Test
+    void testGetUser_invalidPerms() {
+        String validId = "test_id";
+        User sampleUser = new User(
+                "test_id",
+                "testFirstName",
+                "testLastName",
+                "testEmail",
+                "testPhoneNumber",
+                "testPassword",
+                Role.USER,
+                true,
+                new ArrayList<>());
+        when(authentication.getName()).thenReturn(sampleUser.email);
+        when(userRepo.findByEmail(sampleUser.email)).thenReturn(Optional.of(sampleUser));
+        when(userRepo.findById(sampleUser.id)).thenReturn(Optional.of(sampleUser));
+
+        ResponseEntity<User> response = profileController.getUser(validId);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+
+    }
+
+    @Test
     void testProfileDetails() {
         User sampleUser = new User(
                 "test_id",

--- a/backend/nitconf/src/test/java/com/nitconfbackend/nitconf/controllers/ProfileControllerTest.java
+++ b/backend/nitconf/src/test/java/com/nitconfbackend/nitconf/controllers/ProfileControllerTest.java
@@ -1,0 +1,141 @@
+package com.nitconfbackend.nitconf.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import com.nitconfbackend.nitconf.models.Role;
+import com.nitconfbackend.nitconf.models.User;
+import com.nitconfbackend.nitconf.repositories.UserRepository;
+import com.nitconfbackend.nitconf.types.ProfileRequest;
+
+public class ProfileControllerTest {
+
+    @Mock
+    private UserRepository userRepo;
+
+    @InjectMocks
+    private ProfileController profileController;
+
+    @Mock
+    private Authentication authentication;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        SecurityContext securityContext = mock(SecurityContext.class);
+        SecurityContextHolder.setContext(securityContext);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+    }
+
+    @Test
+    void testGetUser() {
+        String validId = "test_id";
+        User sampleUser = new User(
+                "test_id",
+                "testFirstName",
+                "testLastName",
+                "testEmail",
+                "testPhoneNumber",
+                "testPassword",
+                Role.REVIEWER,
+                true,
+                new ArrayList<>());
+        when(authentication.getName()).thenReturn(sampleUser.email);
+        when(userRepo.findByEmail(sampleUser.email)).thenReturn(Optional.of(sampleUser));
+        when(userRepo.findById(sampleUser.id)).thenReturn(Optional.of(sampleUser));
+
+        ResponseEntity<User> response = profileController.getUser(validId);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testGetUser_invalidId() {
+        String invalidId = "invalid_id";
+        User sampleUser = new User(
+                "test_id",
+                "testFirstName",
+                "testLastName",
+                "testEmail",
+                "testPhoneNumber",
+                "testPassword",
+                Role.REVIEWER,
+                true,
+                new ArrayList<>());
+        when(authentication.getName()).thenReturn("testEmail");
+        when(userRepo.findByEmail("testEmail")).thenReturn(Optional.of(sampleUser));
+        when(userRepo.findById(invalidId)).thenReturn(Optional.empty());
+
+        // ResponseEntity<User> response = profileController.getUser(invalidId);
+
+        assertThrows(NoSuchElementException.class, () -> profileController.getUser(invalidId));
+    }
+
+    @Test
+    void testProfileDetails() {
+        User sampleUser = new User(
+                "test_id",
+                "testFirstName",
+                "testLastName",
+                "testEmail",
+                "testPhoneNumber",
+                "testPassword",
+                Role.USER,
+                true,
+                new ArrayList<>());
+        when(authentication.getPrincipal()).thenReturn(sampleUser);
+        assertEquals(HttpStatus.OK, profileController.profileDetails().getStatusCode());
+    }
+
+    @Test
+    void testUpdateProfile() {
+        User sampleUser = new User(
+                "test_id",
+                "testFirstName",
+                "testLastName",
+                "testEmail",
+                "testPhoneNumber",
+                "testPassword",
+                Role.USER,
+                true,
+                new ArrayList<>());
+        ProfileRequest updatedData = new ProfileRequest(
+                "updatedFirstName",
+                "updatedLastName",
+                "updatedPhoneNumber");
+        when(authentication.getName()).thenReturn(sampleUser.email);
+        when(userRepo.findByEmail(sampleUser.email)).thenReturn(Optional.of(sampleUser));
+        when(authentication.getName()).thenReturn(sampleUser.email);
+        when(userRepo.findByEmail(sampleUser.email)).thenReturn(Optional.of(sampleUser));
+        assertEquals(HttpStatus.OK, profileController.updateProfile(updatedData).getStatusCode());
+    }
+
+    @Test
+    void testUpdateProfile_invalidUser() {
+        ProfileRequest updatedData = new ProfileRequest(
+                "updatedFirstName",
+                "updatedLastName",
+                "updatedPhoneNumber");
+        when(authentication.getName()).thenReturn("testEmail");
+        when(userRepo.findByEmail("testEmail")).thenReturn(Optional.empty());
+        assertThrows(NoSuchElementException.class, () -> profileController.updateProfile(updatedData));
+    }
+
+}


### PR DESCRIPTION
### created tests for 
* getUser - a REVIEWER/PC should be able to get any user from their id
* getUser_invalidId - an appropriate error should be thrown when the requested user doesnt exist
* getUser_invalidPermissionn - an appropriate error should be thrown when a USER tries to access another USER's data
* profileDetails - user should be able to get his profile data
* updateProfile - any user should be able to update their own details 
* updateProfile_invalidUser - if the user doesn't exist, an appropriate error should be thrown